### PR TITLE
fix: pass `textlint_flags` correctly to textlint

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -35,7 +35,7 @@ textlint_exit_val="0"
 reviewdog_exit_val="0"
 
 # shellcheck disable=SC2086
-textlint_check_output=$(npx textlint -f checkstyle "${INPUT_TEXTLINT_FLAGS}" 2>&1) \
+textlint_check_output=$(npx textlint -f checkstyle ${INPUT_TEXTLINT_FLAGS} 2>&1) \
                       || textlint_exit_val="$?"
 
 # shellcheck disable=SC2086
@@ -52,7 +52,7 @@ echo '::endgroup::'
 if [[ "${INPUT_REPORTER}" == "github-pr-review" ]]; then
   echo '::group:: Running textlint fixing report 🐶 ...'
   # fix
-  npx textlint --fix "${INPUT_TEXTLINT_FLAGS:-.}" || true
+  npx textlint --fix ${INPUT_TEXTLINT_FLAGS:-.} || true
 
   TMPFILE=$(mktemp)
   git diff >"${TMPFILE}"


### PR DESCRIPTION
## related issue

none

## Fix or Add/Remove this PR/このプルリクエストでやったこと

I fixed passing `textlint_flags` to textlint.
It was interpreted that one string was passed to textlint because it was quoted.

## Not fix or add/remove this PR/このプルリクエストでやらなかったこと

none

## Pros and Cons/メリットとデメリット

none

## Test/動作確認

Test item list up with checkbox, checked after tested./チェックボックス式にし、確認後チェックする。

- [x] Specify multiple values to `textlint_flags` (ex. `"doc1/** doc2/**"`)

