### PR TITLE
yarn と pnpm に対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ Optional. Additional reviewdog flags
 
 textlint arguments (i.e. target dir:`doc/*`)
 
+### `package_manager`
+
+Optional. Package manager used in the repository [npm,yarn,pnpm]
+Default is `npm`.
+
 ## Customizes
 
 `.textlintrc` put in your repo.

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,9 @@ inputs:
   tool_name:
     description: 'Tool name to use for reviewdog reporter'
     default: 'textlint'
+  package_manager:
+    description: 'Package manager used in the repository'
+    default: 'npm'
 runs:
   using: 'composite'
   steps:
@@ -52,6 +55,7 @@ runs:
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
         INPUT_TEXTLINT_FLAGS: ${{ inputs.textlint_flags }}
         INPUT_TOOL_NAME: ${{ inputs.tool_name }}
+        INPUT_PACKAGE_MANAGER: ${{ inputs.package_manager }}
 branding:
   icon: 'alert-octagon'
   color: 'blue'

--- a/script.sh
+++ b/script.sh
@@ -14,6 +14,15 @@ echo '::endgroup::'
 echo '::group:: Installing textlint ...  https://github.com/textlint/textlint'
 if [ -x "./node_modules/.bin/textlint"  ]; then
   echo 'already installed'
+elif INPUT_PACKAGE_MANAGER=npm; then
+  echo 'npm ci start'
+  npm ci
+elif INPUT_PACKAGE_MANAGER=yarn; then
+  echo 'yarn install start'
+  yarn install
+elif INPUT_PACKAGE_MANAGER=pnpm; then
+  echo 'pnpm install start'
+  pnpm install
 else
   echo 'npm ci start'
   npm ci

--- a/script.sh
+++ b/script.sh
@@ -14,13 +14,13 @@ echo '::endgroup::'
 echo '::group:: Installing textlint ...  https://github.com/textlint/textlint'
 if [ -x "./node_modules/.bin/textlint"  ]; then
   echo 'already installed'
-elif INPUT_PACKAGE_MANAGER=npm; then
+elif [[ "${INPUT_PACKAGE_MANAGER}" == "npm" ]]; then
   echo 'npm ci start'
   npm ci
-elif INPUT_PACKAGE_MANAGER=yarn; then
+elif [[ "${INPUT_PACKAGE_MANAGER}" == "yarn" ]]; then
   echo 'yarn install start'
   yarn install
-elif INPUT_PACKAGE_MANAGER=pnpm; then
+elif [[ "${INPUT_PACKAGE_MANAGER}" == "pnpm" ]]; then
   echo 'pnpm install start'
   pnpm install
 else


### PR DESCRIPTION
# Pull Request detail

<!-- ## Related issues or PRs/関連issueやPR

related #.

close #. -->

## Fix or Add/Remove in this PR/このプルリクエストでやったこと

- `package_manager` オプションを設け、yarn と pnpm に対応しました。

<!-- ## Do not fix or add/remove this PR/このプルリクエストでやらなかったこと

- 特になし -->

## Pros and Cons/メリットとデメリット

**メリット**

- yarn や pnpm を使用しているリポジトリで ``The `npm ci\` command can only install with an existing package-lock.json ...`` エラーが発生して止まってしまう状態だったが、このオプションにより問題なく textlint を使用できるようになった。

**デメリット**
なし

## Test/動作確認

Test item list up with checkbox, checked after tested./チェックボックス式にし、確認後チェックする。

- [x] Test / runner / textlint (github-check) (pull_request)
- [x] reviewdog / runner / shellcheck (pull_request)
- [x] Test / runner / textlint (github-pr-check) (pull_request)
- [x] reviewdog / runner / misspell (pull_request)
- [x] Test / runner / textlint (github-pr-review) (pull_request)
- [x] reviewdog / runner / alex (pull_request)
