### PR TITLE
fix: Deprecated fail-on-error, and add support fail-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,20 @@ github-pr-review can use Markdown and add a link to rule page in reviewdog repor
 Optional. Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
 Default is added.
 
+### `fail_level`
+
+Optional.  Exit code control for reviewdog, [none,any,info,warning,error]
+Default is `none`.
+
 ### `fail_on_error`
+
+**Deprecated.**
 
 Optional.  Exit code for reviewdog when errors are found [true,false]
 Default is `false`.
+
+If `true` is set, it will be interpreted as "-fail-level=error".
+But if "-fail-level" is set non-`none`, it will be ignored.
 
 ### `reviewdog_flags`
 

--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,20 @@ inputs:
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
       Default is added.
     default: 'added'
+  fail_level:
+    description: |
+      Optional.  Exit code control for reviewdog, [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
-      Exit code for reviewdog when errors are found [true,false]
+      Deprecated.
+
+      Optional.  Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
+
+      If `true` is set, it will be interpreted as "-fail-level=error".
+      But if "-fail-level" is set non-`none`, it will be ignored.
     default: 'false'
   reviewdog_flags:
     description: 'Additional reviewdog flags'
@@ -51,6 +61,7 @@ runs:
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
+        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
         INPUT_TEXTLINT_FLAGS: ${{ inputs.textlint_flags }}

--- a/script.sh
+++ b/script.sh
@@ -69,7 +69,7 @@ echo "${textlint_check_output}" | reviewdog -f=checkstyle \
         -name="${INPUT_TOOL_NAME}"                        \
         -reporter="${INPUT_REPORTER:-github-pr-review}"   \
         -filter-mode="${INPUT_FILTER_MODE}"               \
-        -fail_level="${fail_level}"                       \
+        -fail-level="${fail_level}"                       \
         -level="${INPUT_LEVEL}"                           \
         ${INPUT_REVIEWDOG_FLAGS} || reviewdog_exit_val="$?"
 echo '::endgroup::'
@@ -92,7 +92,7 @@ if [[ "${INPUT_REPORTER}" == "github-pr-review" ]]; then
     -name="${INPUT_TOOL_NAME}-fix"          \
     -reporter="github-pr-review"            \
     -filter-mode="${INPUT_FILTER_MODE}"     \
-    -fail_level="${fail_level}"             \
+    -fail-level="${fail_level}"             \
     -level="${INPUT_LEVEL}"                 \
     ${INPUT_REVIEWDOG_FLAGS} < "${TMPFILE}" \
     || reviewdog_exit_val2="$?"

--- a/script.sh
+++ b/script.sh
@@ -52,6 +52,14 @@ reviewdog_exit_val="0"
 # ignore preview exit code
 reviewdog_exit_val2="0"
 
+fail_level="${INPUT_FAIL_LEVEL}"
+if [[ "${INPUT_FAIL_LEVEL}" == "none" ]] && [[ "${INPUT_FAIL_ON_ERROR}" == "true" ]]; then
+  fail_level="error"
+fi
+
+echo "report level is: ${INPUT_LEVEL}"
+echo "fail level is: ${fail_level}"
+
 # shellcheck disable=SC2086
 textlint_check_output=$(${PACKAGE_EXECUTER} textlint -f checkstyle ${INPUT_TEXTLINT_FLAGS} 2>&1) \
                       || textlint_exit_val="$?"
@@ -61,7 +69,7 @@ echo "${textlint_check_output}" | reviewdog -f=checkstyle \
         -name="${INPUT_TOOL_NAME}"                        \
         -reporter="${INPUT_REPORTER:-github-pr-review}"   \
         -filter-mode="${INPUT_FILTER_MODE}"               \
-        -fail-on-error="${INPUT_FAIL_ON_ERROR}"           \
+        -fail_level="${fail_level}"                       \
         -level="${INPUT_LEVEL}"                           \
         ${INPUT_REVIEWDOG_FLAGS} || reviewdog_exit_val="$?"
 echo '::endgroup::'
@@ -84,7 +92,7 @@ if [[ "${INPUT_REPORTER}" == "github-pr-review" ]]; then
     -name="${INPUT_TOOL_NAME}-fix"          \
     -reporter="github-pr-review"            \
     -filter-mode="${INPUT_FILTER_MODE}"     \
-    -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
+    -fail_level="${fail_level}"             \
     -level="${INPUT_LEVEL}"                 \
     ${INPUT_REVIEWDOG_FLAGS} < "${TMPFILE}" \
     || reviewdog_exit_val2="$?"


### PR DESCRIPTION
fail-on-error is deprecated.

fail-level instead.

Close #524

See https://github.com/tsuyoshicho/action-test-repo/pull/46